### PR TITLE
use older kernel, if problems with usb-tuner

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -27,4 +27,5 @@ LICENSE_PATH += "${LAYERDIR}/files/custom-licenses"
 # does not belong here ... move me
 DISTRO_FEATURES_DEFAULT = "acl alsa argp bluetooth ext2 irda largefile pcmcia usbgadget usbhost wifi xattr nfs smbfs vfat ext2 acpi ppp zeroconf pci 3g nfc x11 pulseaudio systemd"
 
-
+# Linux 4.10+ has an unresolved problem loading dvb firmwares, use older Kernel if you have problems. 
+# PREFERRED_VERSION_linux-yocto_genericx86-64 ?= "4.4%"


### PR DESCRIPTION
[  110.047257] dvb-usb: found a 'Technotrend TT-connect S-2400' in cold state, will try to load a firmware
[  110.047485] dvb-usb: downloading firmware from file 'dvb-usb-tt-s2400-01.fw'
[  110.047502] dvb-usb: could not stop the USB controller CPU.
[  110.108456] dvb-usb: could not restart the USB controller CPU.